### PR TITLE
feat: support version option

### DIFF
--- a/lib/npm-update.js
+++ b/lib/npm-update.js
@@ -8,9 +8,10 @@ module.exports = function *(options) {
   var name = pkg.name || options.name;
   var protocol = options.protocol || 'http';
   var host = options.host || 'registry.cnpmjs.org';
+  var version = typeof options.version !== 'undefined' ? options.version : 'latest';
 
   var opt = {
-    uri: `${protocol}://${host}/${name}/latest`,
+    uri: `${protocol}://${host}/${name}/${version}`,
     method: 'get',
     timeout: options.timeout || 1000
   };


### PR DESCRIPTION
support custom base version

example:

latest version 2.0.0 and 1.5.0, package version is 1.0.0 

can use options.version 1.x